### PR TITLE
Add image badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # jq
 
 [![](https://images.microbadger.com/badges/image/oildex/ansible-lint.svg)](https://microbadger.com/images/oildex/ansible-lint)
+[![Anchore Image Overview](https://anchore.io/service/badges/image/5b792a7c6a8a7d29ae912fbc162e43b7e32d999c4403d3cb9d01e9af39468a3a)](https://anchore.io/image/dockerhub/oildex%2Fjq%3Alatest)
 
 [jq](https://stedolan.github.io/jq/) is a lightweight and flexible command-line JSON processor.
 


### PR DESCRIPTION
Add images badges from MicroBadger and Anchore.io to the README file. They show the image's size and provide access to more information.